### PR TITLE
Updeted pre-commit deprecated dependency bandite

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,14 +11,14 @@ repos:
     hooks:
       - id: ruff
 
-  - repo: https://github.com/Lucas-C/pre-commit-hooks-bandit
-    rev: v1.0.6
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.8
     hooks:
-    -   id: python-bandit-vulnerability-check
-        args: [ '-x', '.env', 'venv', 'tests' ]
+      - id: bandit
+        args: [ "-c", "pyproject.toml" ]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.10.0
     hooks:
-    -   id: mypy
-        args: [--ignore-missing-imports, --install-types, --non-interactive, --no-warn-return-any]
+      - id: mypy
+        args: [ --ignore-missing-imports, --install-types, --non-interactive, --no-warn-return-any ]


### PR DESCRIPTION
Changed bandit dependency to PyCQA/bandit hook with linking to pyproject.toml config file.